### PR TITLE
Fixed #5 -- Add support for `django-nose` and any other custom test c…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,21 @@ Then add it to your `INSTALLED_APPS` on your `settings.py`:
         'test_without_migrations',
     )
 
+You will want to make sure that `test_without_migrations` appears **before**
+any other apps in ``INSTALLED_APPS`` that provide a custom ``test`` management
+command.
+
+In this case, you will also want to set the ``TEST_WITHOUT_MIGRATIONS_COMMAND``
+setting:
+
+.. code-block:: python
+
+    TEST_WITHOUT_MIGRATIONS_COMMAND = 'django_nose.management.commands.test.Command'
+
+This will ensure that you don't lose any additional functionality provided by
+your custom ``test`` management command.
+
+
 Usage
 -----
 

--- a/test_without_migrations/management/commands/test.py
+++ b/test_without_migrations/management/commands/test.py
@@ -1,7 +1,17 @@
-# coding: utf-8
-from optparse import make_option
-from django.core.management.commands.test import Command as TestCommand
+import optparse
+import sys
+
 from django import VERSION as DJANGO_VERSION
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+TestCommand = import_string(getattr(
+    settings,
+    'TEST_WITHOUT_MIGRATIONS_COMMAND',
+    'django.core.management.commands.test.Command'))
+
+
+HELP = 'Tells Django to NOT use migrations and create all tables directly.'
 
 
 class DisableMigrations(object):
@@ -14,6 +24,7 @@ class DisableMigrations(object):
 
 
 class Command(TestCommand):
+
     def __init__(self):
         super(Command, self).__init__()
 
@@ -21,19 +32,30 @@ class Command(TestCommand):
         # So we only define option_list for Django 1.7
         if DJANGO_VERSION < (1, 8):
             self.option_list = super(Command, self).option_list + (
-                make_option('-n', '--nomigrations', action='store_true', dest='nomigrations', default=False,
-                    help='Tells Django to NOT use migrations and create all tables directly.'),
+                optparse.make_option(
+                    '-n',
+                    '--nomigrations',
+                    action='store_true',
+                    dest='nomigrations',
+                    default=False,
+                    help=HELP),
             )
 
     def add_arguments(self, parser):  # New API on Django 1.8
         super(Command, self).add_arguments(parser)
 
-        parser.add_argument('-n', '--nomigrations',
-            action='store_true', dest='nomigrations', default=False,
-            help='Tells Django to NOT use migrations and create all tables directly.'),
+        parser.add_argument(
+            '-n',
+            '--nomigrations',
+            action='store_true',
+            dest='nomigrations',
+            default=False,
+            help=HELP)
 
     def handle(self, *test_labels, **options):
-        from django.conf import settings
+        for arg in ('-n', '--nomigrations'):
+            if arg in sys.argv:
+                sys.argv.remove(arg)
 
         if options['nomigrations']:
             settings.MIGRATION_MODULES = DisableMigrations()


### PR DESCRIPTION
…ommands.

* Add a `TEST_WITHOUT_MIGRATIONS_COMMAND` setting that should be a dotted path
  to a management command class to use as a base class, to which we will add
  the `-n` and `--nomigrations` arguments.

* Remove `-n` and `--nomigrations` from `sys.arg`, in case we are extending a
  custom that passes these along.