### PR TITLE
Add setting to specify the default behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,15 @@ Version 0.6 also supports `testserver` command:
 
     $ python manage.py testserver --nomigrations myfixture.json
 
+To avoid needing to set a flag on the command line, there is a Django
+setting to specify the default behavior:
+
+.. code-block:: python
+
+    # settings.py
+
+    TEST_WITHOUT_MIGRATIONS_DEFAULT = True
+
 Inspiration
 -----------
 

--- a/test_without_migrations/management/commands/_base.py
+++ b/test_without_migrations/management/commands/_base.py
@@ -15,6 +15,13 @@ TestCommand = import_string(getattr(
     'django.core.management.commands.test.Command'))
 
 
+TEST_WITHOUT_MIGRATIONS_DEFAULT = getattr(
+    settings,
+    'TEST_WITHOUT_MIGRATIONS_DEFAULT',
+    False
+)
+
+
 # testserver command only exists on Django 1.10+
 if DJANGO_VERSION >= (1, 10):
     TestServerCommand = import_string(
@@ -52,7 +59,7 @@ class CommandMixin(object):
                     '--nomigrations',
                     action='store_true',
                     dest='nomigrations',
-                    default=False,
+                    default=TEST_WITHOUT_MIGRATIONS_DEFAULT,
                     help=HELP),
             )
 
@@ -64,7 +71,7 @@ class CommandMixin(object):
             '--nomigrations',
             action='store_true',
             dest='nomigrations',
-            default=False,
+            default=TEST_WITHOUT_MIGRATIONS_DEFAULT,
             help=HELP)
 
     def handle(self, *test_labels, **options):


### PR DESCRIPTION
In order to remove the need to specify the option via the command
line, this commit provides support for a setting to specify the
default behavior. The setting is called
TEST_WITHOUT_MIGRATIONS_DEFAULT, and may be omitted in which case the
default of "False" is used.

Resolves #20